### PR TITLE
Ready-to-use compose files

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,62 @@
+##############################
+# Cheshire Cat Env Variables #
+##############################
+
+# Decide host and port for your Cat. Default will be localhost:1865
+CORE_HOST=localhost
+CORE_PORT=1865
+
+# Qdrant server
+# QDRANT_HOST=localhost
+# QDRANT_PORT=6333
+
+# Decide to use https / wss secure protocols
+#CORE_USE_SECURE_PROTOCOLS=true
+
+# Protect endpoints with an access token
+#API_KEY=meow
+
+# Log levels
+LOG_LEVEL=WARNING
+
+# Turn on memory collections' snapshots on embedder change with SAVE_MEMORY_SNAPSHOTS=true
+SAVE_MEMORY_SNAPSHOTS=false
+
+##################################
+# Llama-cpp server Env Variables #
+##################################
+
+# Ip address and port from which to accept incoming connections
+# LLAMA_HOST=0.0.0.0
+# LLAMA_PORT=8000
+
+# Folder containing the models. This is were Docker mounts a volume
+# Mandatory!
+# MODELS_FOLDER=models
+
+# Name of the model file. This should be inside MODELS_FOLDER
+# Mandatory!
+# MODEL=...
+
+# Length in tokens of the model's context
+# N_CTX=2048
+
+# Number of model's layer to off-load on the GPU
+# N_GPU_LAYERS=0
+
+# Index of the main GPU
+# MAIN_GPU=0
+
+# Number of CPU threads
+# N_THREADS=4
+
+# Number of token to consider for repetition penalty
+# LAST_N_TOKENS_SIZE=64
+
+# Format of the conversation to use
+# CHAT_FORMAT=llama-2
+
+# Whether to interrupt requests when a new request is received
+# INTERRUPT_REQUESTS=True
+
+# Verbose=True

--- a/llamacpp-compose-cpu.yml
+++ b/llamacpp-compose-cpu.yml
@@ -1,0 +1,59 @@
+version: '3.7'
+
+services:
+
+  cheshire-cat-core:
+    build:
+      context: ./core
+    container_name: cheshire_cat_core
+    depends_on:
+      - cheshire-cat-vector-memory
+    environment:
+      - PYTHONUNBUFFERED=1
+      - WATCHFILES_FORCE_POLLING=true
+      - CORE_HOST=${CORE_HOST:-localhost}
+      - CORE_PORT=${CORE_PORT:-1865}
+      - QDRANT_HOST=${QDRANT_HOST:-cheshire_cat_vector_memory}
+      - QDRANT_PORT=${QDRANT_PORT:-6333}
+      - CORE_USE_SECURE_PROTOCOLS=${CORE_USE_SECURE_PROTOCOLS:-}
+      - API_KEY=${API_KEY:-}
+      - LOG_LEVEL=${LOG_LEVEL:-WARNING}
+      - DEBUG=${DEBUG:-true}
+      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-false}
+    ports:
+      - ${CORE_PORT:-1865}:80
+    volumes:
+      - ./core:/app
+    command:
+      - python
+      - "-m"
+      - "cat.main"
+    restart: unless-stopped
+
+  cheshire-cat-vector-memory:
+    image: qdrant/qdrant:v1.1.1
+    container_name: cheshire_cat_vector_memory
+    expose:
+      - 6333
+    volumes:
+      - ./long_term_memory/vector:/qdrant/storage
+    restart: unless-stopped
+
+  llama-cpp-server:
+    image: ghcr.io/abetlen/llama-cpp-python:latest
+    ports:
+      - ${LLAMA_PORT}:8000
+    environment:
+      - HOST=${LLAMA_HOST:-0.0.0.0}
+      - PORT=${LLAMA_PORT:-8000}
+      - MODELS_FOLDER=${MODELS_FOLDER:-models/}
+      - MODEL=/models/${MODEL}
+      - N_CTX=${N_CTX:-2048}
+      - N_THREADS=${N_THREADS:-4}
+      - LAST_N_TOKENS_SIZE=${LAST_N_TOKENS_SIZE:-64}
+      - CHAT_FORMAT=${CHAT_FORMAT:-llama-2}
+      - VERBOSE=${VERBOSE:-True}
+      - INTERRUPT_REQUESTS=${INTERRUPT_REQUESTS:-True}
+    volumes:
+      - ${MODELS_FOLDER}:/models
+    restart: unless-stopped

--- a/llamacpp-compose-gpu.yml
+++ b/llamacpp-compose-gpu.yml
@@ -1,0 +1,68 @@
+version: '3.7'
+
+services:
+
+  cheshire-cat-core:
+    build:
+      context: ./core
+    container_name: cheshire_cat_core
+    depends_on:
+      - cheshire-cat-vector-memory
+    environment:
+      - PYTHONUNBUFFERED=1
+      - WATCHFILES_FORCE_POLLING=true
+      - CORE_HOST=${CORE_HOST:-localhost}
+      - CORE_PORT=${CORE_PORT:-1865}
+      - QDRANT_HOST=${QDRANT_HOST:-cheshire_cat_vector_memory}
+      - QDRANT_PORT=${QDRANT_PORT:-6333}
+      - CORE_USE_SECURE_PROTOCOLS=${CORE_USE_SECURE_PROTOCOLS:-}
+      - API_KEY=${API_KEY:-}
+      - LOG_LEVEL=${LOG_LEVEL:-WARNING}
+      - DEBUG=${DEBUG:-true}
+      - SAVE_MEMORY_SNAPSHOTS=${SAVE_MEMORY_SNAPSHOTS:-false}
+    ports:
+      - ${CORE_PORT:-1865}:80
+    volumes:
+      - ./core:/app
+    command:
+      - python
+      - "-m"
+      - "cat.main"
+    restart: unless-stopped
+
+  cheshire-cat-vector-memory:
+    image: qdrant/qdrant:v1.1.1
+    container_name: cheshire_cat_vector_memory
+    expose:
+      - 6333
+    volumes:
+      - ./long_term_memory/vector:/qdrant/storage
+    restart: unless-stopped
+
+  llama-cpp-server:
+    image: ghcr.io/abetlen/llama-cpp-python:latest
+    ports:
+      - ${LLAMA_PORT}:8000
+    environment:
+      - HOST=${LLAMA_HOST:-0.0.0.0}
+      - PORT=${LLAMA_PORT:-8000}
+      - MODELS_FOLDER=${MODELS_FOLDER:-models/}
+      - MODEL=/models/${MODEL}
+      - N_CTX=${N_CTX:-2048}
+      - N_GPU_LAYERS=${N_GPU_LAYERS:-0}
+      - MAIN_GPU=${MAIN_GPU:-0}
+      - N_THREADS=${N_THREADS:-4}
+      - LAST_N_TOKENS_SIZE=${LAST_N_TOKENS_SIZE:-64}
+      - CHAT_FORMAT=${CHAT_FORMAT:-llama-2}
+      - VERBOSE=${VERBOSE:-True}
+      - INTERRUPT_REQUESTS=${INTERRUPT_REQUESTS:-True}
+    volumes:
+      - ${MODELS_FOLDER}:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds two docker compose files to run models supported by the Llama-cpp server with the Cheshire Cat.

There is one version to run the model on the CPU and another that extends the previous to support GPU off-loading.